### PR TITLE
Remove unnecessary condition from index.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,10 +17,7 @@ const main = async (arg: TMainArgs = 'ls') => {
   const conf = await checkAndGetConfig();
   const pwd = process.cwd();
 
-  if (arg === 'ls' || arg === undefined) {
-    if (!arg) {
-      log.help(logMessages.help);
-    }
+  if (arg === 'ls') {
     await lsCommand(conf);
   } else if (arg === 'rm') {
     await rmCommand(conf, pwd);


### PR DESCRIPTION
If the arg is "undefined", the log.help is called, just like for "else" branch.
So we include the "undefined" case to the "else" branch,

Если у нас попадает в функцию неопределённый аргумент, для него
вызывается функция помощи, что абсолютно идентично последней цепочке
условной конструкции. Таким образом, можно убрать ненужное дополнительное
условие.